### PR TITLE
Add test verifying multiple URL encoded characters are decoded successfully

### DIFF
--- a/modules/__tests__/getParams-test.js
+++ b/modules/__tests__/getParams-test.js
@@ -102,6 +102,16 @@ describe('getParams', function () {
         expect(getParams(pattern, '/users/123')).toBe(null);
       });
     });
+
+    describe('and the path contains multiple special URL encoded characters', function () {
+        var pattern = '/foo/:component';
+
+        describe('and the path matches', function () {
+            it('returns the correctly decoded characters', function () {
+                expect(getParams(pattern, '/foo/%7Bfoo%24bar')).toEqual({ component: '{foo$bar' });
+            });
+        });
+    });
   });
 
   describe('when a pattern has a *', function () {


### PR DESCRIPTION
Referencing issue #1264, this is fixed in the current master branch.  This pull request adds a test case verifying this is the case.
